### PR TITLE
[BUGFIX] Fix reading aria-expanded attribute

### DIFF
--- a/Resources/Public/JavaScript/PageModuleCollapse.js
+++ b/Resources/Public/JavaScript/PageModuleCollapse.js
@@ -24,7 +24,7 @@ define([
 
         // Update the correct status as we are unable to modify the templates
         document.querySelector(btn.dataset.bsTarget).classList.add('collapse');
-        if (btn.ariaExpanded == 'true') {
+        if (btn.getAttribute('aria-expanded') == 'true') {
           document.querySelector(btn.dataset.bsTarget).classList.add('show');
           substituteNode.classList.add('d-none');
         }


### PR DESCRIPTION
Depending on brower version, the value of the aria-expanded attribute could sometimes not be read correctly. This resulted in elements always being collapsed.

Resolves: #11